### PR TITLE
increased nokogiri to version 1.5.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       treetop (~> 1.4.8)
     mime-types (1.19)
     multi_json (1.3.6)
-    nokogiri (1.5.0)
+    nokogiri (1.5.5)
     paperclip (2.5.1)
       activerecord (>= 2.3.0)
       activesupport (>= 2.3.2)


### PR DESCRIPTION
When running bundle install, nokogiri version 1.5.0. will not install correctly, that is why the latest version modified in the gemfile.lock works.
